### PR TITLE
docs: fix ToC link error

### DIFF
--- a/contribution/CONTRIBUTING.md
+++ b/contribution/CONTRIBUTING.md
@@ -8,7 +8,7 @@ This page is not the Constituion of the _Dataverse_. We are providing guidelines
 
 # Table of Contents
 - [Questions or Feedback](#questions-or-feedback)
-- [🤝 How to Contribute?](#🤝-how-to-contribute)
+- [🤝 How to Contribute?](#-how-to-contribute)
 - [Tests](#Tests)
 - [Structure of Dataverse](#structure-of-dataverse)
 - [Design Philosophy](#design-philosophy)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows _dataverse_ guidelines [link](https://github.com/UpstageAI/dataverse/blob/main/contribution/CONTRIBUTING.md#commit-messages):
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## What does this PR do?
<!-- Please describe the link to a relevant issue and current behavior that you are modifying.-->

- Description
    - Fixed a [broken ToC link](https://github.com/UpstageAI/dataverse/blob/main/contribution/CONTRIBUTING.md#%F0%9F%A4%9D-how-to-contribute) in `CONTRIBUTING.md`.
    - This seems to be caused by emoji in the link.