### PR TITLE
FIX: Correct handling of unused 'subset' parameter in fasttext_filter (#54)

### DIFF
--- a/dataverse/etl/quality/language.py
+++ b/dataverse/etl/quality/language.py
@@ -59,8 +59,8 @@ def load_fasttext(
     return _FastText(model_path=str(fasttext_path))
 
 
-def language_predict_fasttext(row, model, top_k: int = 1, score_rounding: int = 2):
-    text = row["text"].replace("\n", "")
+def language_predict_fasttext(row, subset, model, top_k: int = 1, score_rounding: int = 2):
+    text = row[subset].replace("\n", "")
     labels, scores = model.predict(text, k=top_k)
     labels = [label.replace("__label__", "") for label in labels]
 
@@ -135,6 +135,7 @@ def quality___language___fasttext_filter(
     data = data.mapPartitions(
         functools.partial(
             language_predict_fasttext_by_partition,
+            subset=subset,
             top_k=top_k,
             score_rounding=score_rounding,
         )


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows _dataverse_ guidelines [link](https://github.com/UpstageAI/dataverse/blob/main/contribution/CONTRIBUTING.md#commit-guidelines):
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## What does this PR do?
<!-- Please describe the link to a relevant issue and current behavior that you are modifying.-->

- Issue Number: #54 
- Description: Originally, the target column was specified as row["text"] which prevented the subset parameter from working. I changed it to work based on the subset criterion.